### PR TITLE
Build HEART Score calculator end to end

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,79 @@
+# Submission Notes
+
+## Running the Project
+
+The README instructions remain valid for this change:
+
+```bash
+npm install
+docker compose up -d db
+npm run migrate --workspace @mdcalc/api
+npm run dev
+```
+
+The HEART Score page is available at
+`http://localhost:3000/calculators/heart-score`, and the API endpoints live
+under `http://localhost:4000/api/v1/calculators/heart-score`.
+
+## Architecture
+
+The main architectural choice was to keep the HEART Score contract in
+`@mdcalc/shared`: zod validates the five scored inputs, TypeScript types are
+shared by web and API, and the pure calculator owns score, band, and
+interpretation logic. The web uses that package for immediate preview, but the
+API still validates and recomputes everything before returning or saving a
+calculation.
+
+The API follows the existing router, controller, service, repository shape.
+Controllers stay thin, services own calculation and persistence orchestration,
+and the repository owns SQL plus snake_case to camelCase DTO mapping.
+
+## Tradeoffs and Skipped Improvements
+
+I did not add authentication, clinician identity, audit logging, rate limiting,
+or patient-level clinical data modeling. Those would matter for a production
+medical workflow, but they are outside the assignment scope and would add
+contracts that the current exercise does not need.
+
+I also kept the recent calculations refresh path local to the calculator
+component instead of adding React Query, SWR, or another data-fetching
+dependency. A small refresh token is enough for this page; a broader app with
+more cache invalidation needs would justify a shared client data layer.
+
+## Decision I Am Proud Of
+
+The strongest decision is making persistence server-authoritative. The browser
+can only submit the five input scores; the API recomputes the HEART Score result
+with the shared calculator immediately before insert, so a client cannot tamper
+with score, band, or interpretation.
+
+## Area of Uncertainty
+
+The current UI stores only scored categories, not richer clinical context such
+as the exact troponin value, named risk factors, clinician, patient, or encounter.
+That matches the assignment and keeps the calculator focused, but a real product
+would need input from clinical and compliance stakeholders before deciding what
+context should be captured and retained.
+
+## Verification
+
+Commands run during the implementation:
+
+- `npm run test`
+- `npm run test --workspace @mdcalc/api`
+- `npm run test --workspace @mdcalc/shared`
+- `npm run test --workspace @mdcalc/web`
+- `npm run typecheck --workspace @mdcalc/shared`
+- `npm run typecheck --workspace @mdcalc/web`
+- `npm run typecheck --workspace @mdcalc/ui`
+- `git diff --check`
+
+Known verification limits:
+
+- Root `npm run typecheck` was not green because the API workspace still has
+  pre-existing TypeScript configuration issues around files outside `rootDir`
+  and `pino-http` types.
+- Root `npm run lint` was not used as a final gate because the repo does not
+  currently include an ESLint config.
+- I did not run a browser E2E flow or connect to a live Postgres instance for
+  manual persistence verification in this final documentation iteration.

--- a/apps/api/src/db/migrate.ts
+++ b/apps/api/src/db/migrate.ts
@@ -27,6 +27,7 @@ async function run() {
   const applied = await appliedMigrations();
   const files = (await readdir(MIGRATIONS_DIR))
     .filter((name) => name.endsWith('.sql'))
+    .filter((name) => !name.endsWith('.down.sql'))
     .sort();
 
   for (const file of files) {

--- a/apps/api/src/db/migrations/002_heart_score_calculations.down.sql
+++ b/apps/api/src/db/migrations/002_heart_score_calculations.down.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS heart_score_calculations;
+
+-- pgcrypto is created by 002_heart_score_calculations.sql for gen_random_uuid().
+-- Do not drop it blindly; only run DROP EXTENSION IF EXISTS pgcrypto after
+-- verifying no other database objects depend on it.

--- a/apps/api/src/db/migrations/002_heart_score_calculations.sql
+++ b/apps/api/src/db/migrations/002_heart_score_calculations.sql
@@ -1,10 +1,13 @@
--- TODO(candidate):
--- Create the `heart_score_calculations` table that backs the persistence
--- endpoints. At minimum you will want:
---   id           UUID primary key, default gen_random_uuid()
---   inputs       JSONB   (the five validated inputs)
---   score        SMALLINT
---   band         TEXT    (one of 'low' | 'moderate' | 'high')
---   created_at   TIMESTAMPTZ, default NOW()
---
--- Add any indexes you think are worthwhile.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS heart_score_calculations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  inputs JSONB NOT NULL CHECK (jsonb_typeof(inputs) = 'object'),
+  score SMALLINT NOT NULL CHECK (score >= 0 AND score <= 10),
+  band TEXT NOT NULL CHECK (band IN ('low', 'moderate', 'high')),
+  interpretation TEXT NOT NULL CHECK (length(interpretation) > 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS heart_score_calculations_created_at_idx
+  ON heart_score_calculations (created_at DESC);

--- a/apps/api/src/middleware/errorHandler.ts
+++ b/apps/api/src/middleware/errorHandler.ts
@@ -3,8 +3,19 @@ import { ZodError } from 'zod';
 
 import { HttpError } from '../utils/httpError.js';
 
+function isZodError(err: unknown): err is ZodError {
+  return (
+    err instanceof ZodError ||
+    (typeof err === 'object' &&
+      err !== null &&
+      'issues' in err &&
+      'flatten' in err &&
+      typeof err.flatten === 'function')
+  );
+}
+
 export const errorHandler: ErrorRequestHandler = (err, req, res, _next) => {
-  if (err instanceof ZodError) {
+  if (isZodError(err)) {
     res.status(400).json({
       error: {
         code: 'VALIDATION_ERROR',

--- a/apps/api/src/modules/calculators/heart-score/heart-score.controller.ts
+++ b/apps/api/src/modules/calculators/heart-score/heart-score.controller.ts
@@ -1,6 +1,27 @@
 import type { Request, Response, NextFunction } from 'express';
 
+import { HttpError } from '../../../utils/httpError.js';
 import { heartScoreService } from './heart-score.service.js';
+
+const DEFAULT_RECENT_CALCULATIONS_LIMIT = 20;
+const MAX_RECENT_CALCULATIONS_LIMIT = 100;
+
+function parseRecentCalculationsLimit(rawLimit: Request['query'][string]): number {
+  if (rawLimit === undefined) {
+    return DEFAULT_RECENT_CALCULATIONS_LIMIT;
+  }
+
+  if (Array.isArray(rawLimit) || typeof rawLimit !== 'string') {
+    throw HttpError.badRequest('Limit must be an integer from 1 to 100');
+  }
+
+  const limit = Number(rawLimit);
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_RECENT_CALCULATIONS_LIMIT) {
+    throw HttpError.badRequest('Limit must be an integer from 1 to 100');
+  }
+
+  return limit;
+}
 
 /**
  * Thin HTTP layer. All calculation and persistence logic lives in the
@@ -26,5 +47,13 @@ export const heartScoreController = {
     }
   },
 
-  // TODO(candidate): implement `list` (GET /calculations).
+  async list(req: Request, res: Response, next: NextFunction) {
+    try {
+      const limit = parseRecentCalculationsLimit(req.query.limit);
+      const calculations = await heartScoreService.listRecentCalculations(limit);
+      res.status(200).json(calculations);
+    } catch (err) {
+      next(err);
+    }
+  },
 };

--- a/apps/api/src/modules/calculators/heart-score/heart-score.controller.ts
+++ b/apps/api/src/modules/calculators/heart-score/heart-score.controller.ts
@@ -17,6 +17,14 @@ export const heartScoreController = {
     }
   },
 
-  // TODO(candidate): implement `create` (POST /calculations) and
-  // `list`     (GET  /calculations).
+  async create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const calculation = await heartScoreService.createCalculation(req.body);
+      res.status(201).json(calculation);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  // TODO(candidate): implement `list` (GET /calculations).
 };

--- a/apps/api/src/modules/calculators/heart-score/heart-score.repository.ts
+++ b/apps/api/src/modules/calculators/heart-score/heart-score.repository.ts
@@ -3,26 +3,53 @@ import type {
   HeartScoreResult,
   PersistedHeartScoreCalculation,
 } from '@mdcalc/shared';
+import { heartScoreInputSchema } from '@mdcalc/shared';
 
 import { pool } from '../../../db/client.js';
 
-/**
- * Data-access layer for `heart_score_calculations`. The service should be
- * the only caller — keep SQL and row-to-DTO mapping inside this file.
- *
- * TODO(candidate): implement `insert` and `listRecent` against the table
- * created in `src/db/migrations/002_heart_score_calculations.sql`.
- */
+interface HeartScoreCalculationRow {
+  id: string;
+  inputs: unknown;
+  score: number;
+  band: HeartScoreResult['band'];
+  interpretation: string;
+  created_at: string | Date;
+}
+
+function mapRow(row: HeartScoreCalculationRow): PersistedHeartScoreCalculation {
+  return {
+    id: row.id,
+    inputs: heartScoreInputSchema.parse(row.inputs),
+    score: row.score,
+    band: row.band,
+    interpretation: row.interpretation,
+    createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+  };
+}
+
 export const heartScoreRepository = {
-  async insert(_input: HeartScoreInput, _result: HeartScoreResult): Promise<PersistedHeartScoreCalculation> {
-    throw new Error('not implemented');
+  async insert(
+    input: HeartScoreInput,
+    result: HeartScoreResult,
+  ): Promise<PersistedHeartScoreCalculation> {
+    const { rows } = await pool.query<HeartScoreCalculationRow>(
+      `
+        INSERT INTO heart_score_calculations (inputs, score, band, interpretation)
+        VALUES ($1, $2, $3, $4)
+        RETURNING id, inputs, score, band, interpretation, created_at
+      `,
+      [input, result.score, result.band, result.interpretation],
+    );
+
+    const [row] = rows;
+    if (!row) {
+      throw new Error('Insert did not return a HEART Score calculation');
+    }
+
+    return mapRow(row);
   },
 
   async listRecent(_limit: number): Promise<PersistedHeartScoreCalculation[]> {
     throw new Error('not implemented');
   },
 };
-
-// Placeholder so editors don't flag `pool` as unused while the repository
-// is stubbed. Safe to remove once the queries above are implemented.
-void pool;

--- a/apps/api/src/modules/calculators/heart-score/heart-score.repository.ts
+++ b/apps/api/src/modules/calculators/heart-score/heart-score.repository.ts
@@ -49,7 +49,17 @@ export const heartScoreRepository = {
     return mapRow(row);
   },
 
-  async listRecent(_limit: number): Promise<PersistedHeartScoreCalculation[]> {
-    throw new Error('not implemented');
+  async listRecent(limit: number): Promise<PersistedHeartScoreCalculation[]> {
+    const { rows } = await pool.query<HeartScoreCalculationRow>(
+      `
+        SELECT id, inputs, score, band, interpretation, created_at
+        FROM heart_score_calculations
+        ORDER BY created_at DESC
+        LIMIT $1
+      `,
+      [limit],
+    );
+
+    return rows.map(mapRow);
   },
 };

--- a/apps/api/src/modules/calculators/heart-score/heart-score.router.ts
+++ b/apps/api/src/modules/calculators/heart-score/heart-score.router.ts
@@ -6,18 +6,7 @@ import { heartScoreController } from './heart-score.controller.js';
 
 export const heartScoreRouter = Router();
 
-/**
- * TODO(candidate): wire the three endpoints described in ASSIGNMENT.md.
- *
- * - POST   /calculate       -> controller.calculate
- * - POST   /calculations    -> controller.create
- * - GET    /calculations    -> controller.list
- *
- * Use `validateBody(heartScoreInputSchema)` on the POST routes once the
- * schema is implemented. The GET route should validate its query params
- * (limit: optional int, 1..100, default 20).
- */
 heartScoreRouter.post('/calculate', validateBody(heartScoreInputSchema), heartScoreController.calculate);
+heartScoreRouter.post('/calculations', validateBody(heartScoreInputSchema), heartScoreController.create);
 
-// heartScoreRouter.post('/calculations', validateBody(heartScoreInputSchema), heartScoreController.create);
 // heartScoreRouter.get('/calculations', heartScoreController.list);

--- a/apps/api/src/modules/calculators/heart-score/heart-score.router.ts
+++ b/apps/api/src/modules/calculators/heart-score/heart-score.router.ts
@@ -6,7 +6,14 @@ import { heartScoreController } from './heart-score.controller.js';
 
 export const heartScoreRouter = Router();
 
-heartScoreRouter.post('/calculate', validateBody(heartScoreInputSchema), heartScoreController.calculate);
-heartScoreRouter.post('/calculations', validateBody(heartScoreInputSchema), heartScoreController.create);
-
-// heartScoreRouter.get('/calculations', heartScoreController.list);
+heartScoreRouter.post(
+  '/calculate',
+  validateBody(heartScoreInputSchema),
+  heartScoreController.calculate,
+);
+heartScoreRouter.post(
+  '/calculations',
+  validateBody(heartScoreInputSchema),
+  heartScoreController.create,
+);
+heartScoreRouter.get('/calculations', heartScoreController.list);

--- a/apps/api/src/modules/calculators/heart-score/heart-score.service.ts
+++ b/apps/api/src/modules/calculators/heart-score/heart-score.service.ts
@@ -17,9 +17,8 @@ export const heartScoreService = {
     return heartScoreRepository.insert(input, result);
   },
 
-  async listRecentCalculations(_limit: number): Promise<PersistedHeartScoreCalculation[]> {
-    // TODO(candidate): delegate to `heartScoreRepository.listRecent(limit)`
-    throw new Error('not implemented');
+  async listRecentCalculations(limit: number): Promise<PersistedHeartScoreCalculation[]> {
+    return heartScoreRepository.listRecent(limit);
   },
 };
 

--- a/apps/api/src/modules/calculators/heart-score/heart-score.service.ts
+++ b/apps/api/src/modules/calculators/heart-score/heart-score.service.ts
@@ -12,12 +12,9 @@ export const heartScoreService = {
     return calculateHeartScore(input);
   },
 
-  async createCalculation(_input: HeartScoreInput): Promise<PersistedHeartScoreCalculation> {
-    // TODO(candidate):
-    //   1. calculate the score via `calculateHeartScore`
-    //   2. persist via `heartScoreRepository.insert(...)`
-    //   3. return the persisted row
-    throw new Error('not implemented');
+  async createCalculation(input: HeartScoreInput): Promise<PersistedHeartScoreCalculation> {
+    const result = calculateHeartScore(input);
+    return heartScoreRepository.insert(input, result);
   },
 
   async listRecentCalculations(_limit: number): Promise<PersistedHeartScoreCalculation[]> {
@@ -27,5 +24,3 @@ export const heartScoreService = {
 };
 
 export type HeartScoreService = typeof heartScoreService;
-// Keep the import even if unused until the candidate wires it up.
-void heartScoreRepository;

--- a/apps/api/tests/calculators/heart-score.test.ts
+++ b/apps/api/tests/calculators/heart-score.test.ts
@@ -123,7 +123,7 @@ describe('POST /api/v1/calculators/heart-score/calculations', () => {
 
   it('returns the structured validation error without persisting invalid scored inputs', async () => {
     const app = createApp();
-    db.query.mockClear();
+    db.query.mockReset();
 
     const res = await request(app).post('/api/v1/calculators/heart-score/calculations').send({
       history: 2,
@@ -205,7 +205,7 @@ describe('GET /api/v1/calculators/heart-score/calculations', () => {
     'rejects invalid recent-calculation limit %s',
     async (limit) => {
       const app = createApp();
-      db.query.mockClear();
+      db.query.mockReset();
 
       const res = await request(app).get(
         `/api/v1/calculators/heart-score/calculations?limit=${limit}`,

--- a/apps/api/tests/calculators/heart-score.test.ts
+++ b/apps/api/tests/calculators/heart-score.test.ts
@@ -1,11 +1,56 @@
-/**
- * TODO(candidate): add unit tests for the scoring function (in
- * @mdcalc/shared) and at least one integration test here that exercises
- * POST /api/v1/calculators/heart-score/calculate with supertest.
- *
- * Good coverage ideas:
- *   - Each band boundary (0-3, 4-6, 7-10).
- *   - Invalid payloads -> 400 with VALIDATION_ERROR.
- *   - Persistence round-trip (use a mocked repository).
- */
-export {};
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/db/client.js', () => ({
+  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) },
+  closePool: vi.fn(),
+}));
+
+import { createApp } from '../../src/app.js';
+
+describe('POST /api/v1/calculators/heart-score/calculate', () => {
+  it('returns a calculated HEART Score result for valid scored inputs', async () => {
+    const app = createApp();
+
+    const res = await request(app).post('/api/v1/calculators/heart-score/calculate').send({
+      history: 2,
+      ecg: 1,
+      age: 1,
+      riskFactors: 1,
+      troponin: 0,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      score: 5,
+      band: 'moderate',
+      interpretation: '12-16.6% 6-week MACE risk. Admit for observation / further workup.',
+      inputs: {
+        history: 2,
+        ecg: 1,
+        age: 1,
+        riskFactors: 1,
+        troponin: 0,
+      },
+    });
+  });
+
+  it('returns the structured validation error for invalid scored inputs', async () => {
+    const app = createApp();
+
+    const res = await request(app).post('/api/v1/calculators/heart-score/calculate').send({
+      history: 2,
+      ecg: 4,
+      age: 1,
+      riskFactors: 1,
+      troponin: 0,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: 'Request payload failed validation',
+    });
+    expect(res.body.error.details.fieldErrors.ecg).toBeDefined();
+  });
+});

--- a/apps/api/tests/calculators/heart-score.test.ts
+++ b/apps/api/tests/calculators/heart-score.test.ts
@@ -1,8 +1,12 @@
 import request from 'supertest';
 import { describe, expect, it, vi } from 'vitest';
 
+const db = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
 vi.mock('../../src/db/client.js', () => ({
-  pool: { query: vi.fn().mockResolvedValue({ rows: [] }) },
+  pool: { query: db.query },
   closePool: vi.fn(),
 }));
 
@@ -52,5 +56,91 @@ describe('POST /api/v1/calculators/heart-score/calculate', () => {
       message: 'Request payload failed validation',
     });
     expect(res.body.error.details.fieldErrors.ecg).toBeDefined();
+  });
+});
+
+describe('POST /api/v1/calculators/heart-score/calculations', () => {
+  it('recomputes and persists a HEART Score calculation from valid scored inputs', async () => {
+    const app = createApp();
+    db.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: '018f190f-0dc8-7487-b35d-123456789abc',
+          inputs: {
+            history: 2,
+            ecg: 2,
+            age: 1,
+            riskFactors: 1,
+            troponin: 1,
+          },
+          score: 7,
+          band: 'high',
+          interpretation: '50-65% 6-week MACE risk. Early invasive strategy.',
+          created_at: '2026-05-03T10:00:00.000Z',
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .post('/api/v1/calculators/heart-score/calculations')
+      .send({
+        history: 2,
+        ecg: 2,
+        age: 1,
+        riskFactors: 1,
+        troponin: 1,
+        score: 0,
+        band: 'low',
+        interpretation: 'client supplied result should be ignored',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({
+      id: '018f190f-0dc8-7487-b35d-123456789abc',
+      inputs: {
+        history: 2,
+        ecg: 2,
+        age: 1,
+        riskFactors: 1,
+        troponin: 1,
+      },
+      score: 7,
+      band: 'high',
+      interpretation: '50-65% 6-week MACE risk. Early invasive strategy.',
+      createdAt: '2026-05-03T10:00:00.000Z',
+    });
+    expect(db.query).toHaveBeenCalledWith(expect.any(String), [
+      {
+        history: 2,
+        ecg: 2,
+        age: 1,
+        riskFactors: 1,
+        troponin: 1,
+      },
+      7,
+      'high',
+      '50-65% 6-week MACE risk. Early invasive strategy.',
+    ]);
+  });
+
+  it('returns the structured validation error without persisting invalid scored inputs', async () => {
+    const app = createApp();
+    db.query.mockClear();
+
+    const res = await request(app).post('/api/v1/calculators/heart-score/calculations').send({
+      history: 2,
+      ecg: 1,
+      age: 3,
+      riskFactors: 1,
+      troponin: 0,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: 'Request payload failed validation',
+    });
+    expect(res.body.error.details.fieldErrors.age).toBeDefined();
+    expect(db.query).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/tests/calculators/heart-score.test.ts
+++ b/apps/api/tests/calculators/heart-score.test.ts
@@ -81,18 +81,16 @@ describe('POST /api/v1/calculators/heart-score/calculations', () => {
       ],
     });
 
-    const res = await request(app)
-      .post('/api/v1/calculators/heart-score/calculations')
-      .send({
-        history: 2,
-        ecg: 2,
-        age: 1,
-        riskFactors: 1,
-        troponin: 1,
-        score: 0,
-        band: 'low',
-        interpretation: 'client supplied result should be ignored',
-      });
+    const res = await request(app).post('/api/v1/calculators/heart-score/calculations').send({
+      history: 2,
+      ecg: 2,
+      age: 1,
+      riskFactors: 1,
+      troponin: 1,
+      score: 0,
+      band: 'low',
+      interpretation: 'client supplied result should be ignored',
+    });
 
     expect(res.status).toBe(201);
     expect(res.body).toEqual({
@@ -143,4 +141,82 @@ describe('POST /api/v1/calculators/heart-score/calculations', () => {
     expect(res.body.error.details.fieldErrors.age).toBeDefined();
     expect(db.query).not.toHaveBeenCalled();
   });
+});
+
+describe('GET /api/v1/calculators/heart-score/calculations', () => {
+  it('returns the 20 most recent saved HEART Score calculations by default', async () => {
+    const app = createApp();
+    db.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: '018f190f-0dc8-7487-b35d-123456789abc',
+          inputs: {
+            history: 2,
+            ecg: 1,
+            age: 1,
+            riskFactors: 1,
+            troponin: 0,
+          },
+          score: 5,
+          band: 'moderate',
+          interpretation: '12-16.6% 6-week MACE risk. Admit for observation / further workup.',
+          created_at: '2026-05-03T10:00:00.000Z',
+        },
+      ],
+    });
+
+    const res = await request(app).get('/api/v1/calculators/heart-score/calculations');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      {
+        id: '018f190f-0dc8-7487-b35d-123456789abc',
+        inputs: {
+          history: 2,
+          ecg: 1,
+          age: 1,
+          riskFactors: 1,
+          troponin: 0,
+        },
+        score: 5,
+        band: 'moderate',
+        interpretation: '12-16.6% 6-week MACE risk. Admit for observation / further workup.',
+        createdAt: '2026-05-03T10:00:00.000Z',
+      },
+    ]);
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('ORDER BY created_at DESC'),
+      [20],
+    );
+  });
+
+  it('uses a valid explicit recent-calculation limit', async () => {
+    const app = createApp();
+    db.query.mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app).get('/api/v1/calculators/heart-score/calculations?limit=3');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+    expect(db.query).toHaveBeenCalledWith(expect.stringContaining('LIMIT $1'), [3]);
+  });
+
+  it.each(['0', '101', '2.5', 'recent'])(
+    'rejects invalid recent-calculation limit %s',
+    async (limit) => {
+      const app = createApp();
+      db.query.mockClear();
+
+      const res = await request(app).get(
+        `/api/v1/calculators/heart-score/calculations?limit=${limit}`,
+      );
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatchObject({
+        code: 'BAD_REQUEST',
+        message: 'Limit must be an integer from 1 to 100',
+      });
+      expect(db.query).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/apps/web/src/app/calculators/heart-score/page.tsx
+++ b/apps/web/src/app/calculators/heart-score/page.tsx
@@ -1,5 +1,4 @@
 import { HeartScoreCalculator } from '@/components/calculators/heart-score/HeartScoreCalculator';
-import { RecentCalculations } from '@/components/calculators/heart-score/RecentCalculations';
 
 export const metadata = {
   title: 'HEART Score for Major Cardiac Events — MDCalc',
@@ -11,16 +10,12 @@ export default function HeartScorePage() {
       <header>
         <h1>HEART Score for Major Cardiac Events</h1>
         <p>
-          Predicts 6-week risk of major adverse cardiac events (MACE) in patients
-          presenting with chest pain. Use alongside clinical judgment — this tool
-          does not replace it.
+          Predicts 6-week risk of major adverse cardiac events (MACE) in patients presenting with
+          chest pain. Use alongside clinical judgment — this tool does not replace it.
         </p>
       </header>
 
-      {/* TODO(candidate): ensure the form is accessible and keyboard-friendly.  */}
       <HeartScoreCalculator />
-
-      <RecentCalculations />
     </section>
   );
 }

--- a/apps/web/src/components/calculators/heart-score/HeartScoreCalculator.test.tsx
+++ b/apps/web/src/components/calculators/heart-score/HeartScoreCalculator.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { HeartScoreCalculator } from './HeartScoreCalculator';
+
+describe('HeartScoreCalculator', () => {
+  it('renders the HEART categories and an initial live result', () => {
+    const html = renderToStaticMarkup(<HeartScoreCalculator />);
+
+    expect(html).toContain('History');
+    expect(html).toContain('ECG');
+    expect(html).toContain('Age');
+    expect(html).toContain('Risk factors');
+    expect(html).toContain('Troponin');
+    expect(html).toContain('Score 0');
+    expect(html).toContain('low');
+    expect(html).toContain('0.9-1.7% 6-week MACE risk');
+  });
+});

--- a/apps/web/src/components/calculators/heart-score/HeartScoreCalculator.test.tsx
+++ b/apps/web/src/components/calculators/heart-score/HeartScoreCalculator.test.tsx
@@ -14,7 +14,11 @@ describe('HeartScoreCalculator', () => {
     expect(html).toContain('Risk factors');
     expect(html).toContain('Troponin');
     expect(html).toContain('Score 0');
-    expect(html).toContain('low');
+    expect(
+      html
+        .match(/<strong[^>]*>Score 0<\/strong><span[^>]*>\s*([^<]+)\s*<\/span>/)?.[1]
+        ?.trim(),
+    ).toBe('low');
     expect(html).toContain('0.9-1.7% 6-week MACE risk');
   });
 });

--- a/apps/web/src/components/calculators/heart-score/HeartScoreCalculator.tsx
+++ b/apps/web/src/components/calculators/heart-score/HeartScoreCalculator.tsx
@@ -1,31 +1,180 @@
 'use client';
 
-/**
- * TODO(candidate):
- *   - Build a form with the five HEART Score inputs using the <RadioGroup />
- *     component from `@mdcalc/ui`.
- *   - Keep form state local (`useState` / `useReducer` — your call).
- *   - On every change, call `calculateHeartScore(input)` from `@mdcalc/shared`
- *     to render a live score + band + interpretation summary.
- *   - Add a "Save calculation" button that POSTs to the API via
- *     `createHeartScoreCalculation` from `@/lib/api/heart-score` and shows a
- *     success/error banner.
- *   - Trigger a refresh of the recent-calculations panel after a successful
- *     save (lift state or use a simple event bus — your call).
- *
- * Keep presentational concerns here; don't import from `pg` or `express`.
- */
+import React, { useMemo, useState } from 'react';
+
+import { calculateHeartScore, type HeartScoreInput } from '@mdcalc/shared';
+import { Button, Card, RadioGroup, type RadioOption } from '@mdcalc/ui';
+
+import { RecentCalculations } from './RecentCalculations';
+import { createHeartScoreCalculation } from '../../../lib/api/heart-score';
+
+type HeartScoreField = keyof HeartScoreInput;
+type HeartScoreValue = HeartScoreInput[HeartScoreField];
+
+type SaveState =
+  | { status: 'idle' }
+  | { status: 'saving' }
+  | { status: 'success'; message: string }
+  | { status: 'error'; message: string };
+
+interface HeartScoreCategory {
+  field: HeartScoreField;
+  legend: string;
+  helperText: string;
+  options: ReadonlyArray<RadioOption<HeartScoreValue>>;
+}
+
+const defaultInput: HeartScoreInput = {
+  history: 0,
+  ecg: 0,
+  age: 0,
+  riskFactors: 0,
+  troponin: 0,
+};
+
+const categories: ReadonlyArray<HeartScoreCategory> = [
+  {
+    field: 'history',
+    legend: 'History',
+    helperText: 'Clinical suspicion from the presenting story.',
+    options: [
+      { value: 0, label: 'Slightly suspicious' },
+      { value: 1, label: 'Moderately suspicious' },
+      { value: 2, label: 'Highly suspicious' },
+    ],
+  },
+  {
+    field: 'ecg',
+    legend: 'ECG',
+    helperText: 'Initial ECG findings.',
+    options: [
+      { value: 0, label: 'Normal' },
+      { value: 1, label: 'Nonspecific repolarization disturbance' },
+      { value: 2, label: 'Significant ST deviation' },
+    ],
+  },
+  {
+    field: 'age',
+    legend: 'Age',
+    helperText: 'Patient age at presentation.',
+    options: [
+      { value: 0, label: '<45 years' },
+      { value: 1, label: '45-64 years' },
+      { value: 2, label: '>=65 years' },
+    ],
+  },
+  {
+    field: 'riskFactors',
+    legend: 'Risk factors',
+    helperText: 'Cardiac risk factor burden.',
+    options: [
+      { value: 0, label: 'No known risk factors' },
+      { value: 1, label: '1-2 risk factors' },
+      { value: 2, label: '>=3 risk factors or known atherosclerotic disease' },
+    ],
+  },
+  {
+    field: 'troponin',
+    legend: 'Troponin',
+    helperText: 'Initial troponin relative to the local normal limit.',
+    options: [
+      { value: 0, label: '<= normal limit' },
+      { value: 1, label: '1-3x normal limit' },
+      { value: 2, label: '>3x normal limit' },
+    ],
+  },
+];
+
 export function HeartScoreCalculator() {
+  const [input, setInput] = useState<HeartScoreInput>(defaultInput);
+  const [saveState, setSaveState] = useState<SaveState>({ status: 'idle' });
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  const result = useMemo(() => calculateHeartScore(input), [input]);
+  const isSaving = saveState.status === 'saving';
+
+  function updateInput(field: HeartScoreField, value: HeartScoreValue) {
+    setInput((current) => ({ ...current, [field]: value }));
+    if (saveState.status !== 'idle') {
+      setSaveState({ status: 'idle' });
+    }
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSaveState({ status: 'saving' });
+
+    try {
+      const saved = await createHeartScoreCalculation(input);
+      setSaveState({
+        status: 'success',
+        message: `Saved calculation ${saved.score} (${saved.band}).`,
+      });
+      setRefreshToken((current) => current + 1);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unable to save calculation';
+      setSaveState({ status: 'error', message });
+    }
+  }
+
   return (
-    <div
-      style={{
-        border: '1px dashed #9ca3af',
-        borderRadius: 8,
-        padding: '1.5rem',
-        color: '#6b7280',
-      }}
-    >
-      <strong>TODO:</strong> implement the HEART Score form and live result here.
+    <div style={{ display: 'grid', gap: '1rem' }}>
+      <div
+        style={{
+          alignItems: 'start',
+          display: 'grid',
+          gap: '1rem',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(18rem, 1fr))',
+        }}
+      >
+        <Card title="Calculator">
+          <form onSubmit={handleSubmit} style={{ display: 'grid', gap: '1.25rem' }}>
+            {categories.map((category) => (
+              <RadioGroup
+                key={category.field}
+                name={category.field}
+                legend={category.legend}
+                helperText={category.helperText}
+                value={input[category.field]}
+                options={category.options}
+                onChange={(value) => updateInput(category.field, value)}
+              />
+            ))}
+
+            <div style={{ display: 'grid', gap: '0.5rem' }}>
+              <Button type="submit" disabled={isSaving}>
+                {isSaving ? 'Saving...' : 'Save calculation'}
+              </Button>
+
+              {saveState.status === 'success' ? (
+                <p role="status" style={{ color: '#047857', margin: 0 }}>
+                  {saveState.message}
+                </p>
+              ) : null}
+
+              {saveState.status === 'error' ? (
+                <p role="alert" style={{ color: '#b91c1c', margin: 0 }}>
+                  {saveState.message}
+                </p>
+              ) : null}
+            </div>
+          </form>
+        </Card>
+
+        <Card title="Live result">
+          <div style={{ display: 'grid', gap: '0.75rem' }}>
+            <div style={{ alignItems: 'baseline', display: 'flex', gap: '0.75rem' }}>
+              <strong style={{ fontSize: '2rem' }}>Score {result.score}</strong>
+              <span style={{ color: '#374151', fontWeight: 600, textTransform: 'capitalize' }}>
+                {result.band}
+              </span>
+            </div>
+            <p style={{ color: '#374151', margin: 0 }}>{result.interpretation}</p>
+          </div>
+        </Card>
+      </div>
+
+      <RecentCalculations refreshToken={refreshToken} />
     </div>
   );
 }

--- a/apps/web/src/components/calculators/heart-score/RecentCalculations.tsx
+++ b/apps/web/src/components/calculators/heart-score/RecentCalculations.tsx
@@ -1,17 +1,110 @@
 'use client';
 
-/**
- * TODO(candidate): fetch recent calculations from the API and render them in
- * a simple list or table. Show the inputs, the score, and the band. Handle
- * loading and error states explicitly.
- */
-export function RecentCalculations() {
+import { useEffect, useState } from 'react';
+
+import type { PersistedHeartScoreCalculation } from '@mdcalc/shared';
+import { Card } from '@mdcalc/ui';
+
+import { listHeartScoreCalculations } from '@/lib/api/heart-score';
+
+type LoadState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'success'; calculations: PersistedHeartScoreCalculation[] };
+
+const inputLabels: Array<[keyof PersistedHeartScoreCalculation['inputs'], string]> = [
+  ['history', 'History'],
+  ['ecg', 'ECG'],
+  ['age', 'Age'],
+  ['riskFactors', 'Risk factors'],
+  ['troponin', 'Troponin'],
+];
+
+function formatCreatedAt(value: string) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}
+
+function formatInputs(calculation: PersistedHeartScoreCalculation) {
+  return inputLabels.map(([key, label]) => `${label} ${calculation.inputs[key]}`).join(' | ');
+}
+
+export function RecentCalculations({ refreshToken = 0 }: { refreshToken?: number }) {
+  const [state, setState] = useState<LoadState>({ status: 'loading' });
+
+  useEffect(() => {
+    let isCurrent = true;
+    setState({ status: 'loading' });
+
+    listHeartScoreCalculations()
+      .then((calculations) => {
+        if (isCurrent) {
+          setState({ status: 'success', calculations });
+        }
+      })
+      .catch((err: unknown) => {
+        if (isCurrent) {
+          const message = err instanceof Error ? err.message : 'Unable to load recent calculations';
+          setState({ status: 'error', message });
+        }
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [refreshToken]);
+
   return (
-    <section>
-      <h2>Recent calculations</h2>
-      <p style={{ color: '#6b7280' }}>
-        TODO: list the most recent saved HEART Score calculations.
-      </p>
-    </section>
+    <Card title="Recent calculations">
+      {state.status === 'loading' ? (
+        <p style={{ color: '#6b7280', margin: 0 }}>Loading recent calculations...</p>
+      ) : null}
+
+      {state.status === 'error' ? (
+        <p role="alert" style={{ color: '#b91c1c', margin: 0 }}>
+          {state.message}
+        </p>
+      ) : null}
+
+      {state.status === 'success' && state.calculations.length === 0 ? (
+        <p style={{ color: '#6b7280', margin: 0 }}>No saved calculations yet.</p>
+      ) : null}
+
+      {state.status === 'success' && state.calculations.length > 0 ? (
+        <ul style={{ display: 'grid', gap: '0.75rem', listStyle: 'none', margin: 0, padding: 0 }}>
+          {state.calculations.map((calculation) => (
+            <li
+              key={calculation.id}
+              style={{
+                border: '1px solid #e5e7eb',
+                borderRadius: 8,
+                display: 'grid',
+                gap: '0.375rem',
+                padding: '0.875rem',
+              }}
+            >
+              <div style={{ alignItems: 'baseline', display: 'flex', gap: '0.75rem' }}>
+                <strong>Score {calculation.score}</strong>
+                <span style={{ color: '#374151', textTransform: 'capitalize' }}>
+                  {calculation.band}
+                </span>
+                <time
+                  dateTime={calculation.createdAt}
+                  style={{ color: '#6b7280', marginLeft: 'auto' }}
+                >
+                  {formatCreatedAt(calculation.createdAt)}
+                </time>
+              </div>
+              <p style={{ color: '#374151', margin: 0 }}>{calculation.interpretation}</p>
+              <p style={{ color: '#6b7280', fontSize: '0.875rem', margin: 0 }}>
+                {formatInputs(calculation)}
+              </p>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </Card>
   );
 }

--- a/apps/web/src/components/calculators/heart-score/RecentCalculations.tsx
+++ b/apps/web/src/components/calculators/heart-score/RecentCalculations.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import React from 'react';
 import { useEffect, useState } from 'react';
 
 import type { PersistedHeartScoreCalculation } from '@mdcalc/shared';
 import { Card } from '@mdcalc/ui';
 
-import { listHeartScoreCalculations } from '@/lib/api/heart-score';
+import { listHeartScoreCalculations } from '../../../lib/api/heart-score';
 
 type LoadState =
   | { status: 'loading' }

--- a/apps/web/src/lib/api/heart-score.test.ts
+++ b/apps/web/src/lib/api/heart-score.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { listHeartScoreCalculations } from './heart-score';
+
+describe('listHeartScoreCalculations', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches recent HEART Score calculations through the shared API client', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue([
+        {
+          id: '018f190f-0dc8-7487-b35d-123456789abc',
+          inputs: {
+            history: 2,
+            ecg: 1,
+            age: 1,
+            riskFactors: 1,
+            troponin: 0,
+          },
+          score: 5,
+          band: 'moderate',
+          interpretation: '12-16.6% 6-week MACE risk. Admit for observation / further workup.',
+          createdAt: '2026-05-03T10:00:00.000Z',
+        },
+      ]),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const calculations = await listHeartScoreCalculations(3);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:4000/api/v1/calculators/heart-score/calculations?limit=3',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'content-type': 'application/json' }),
+      }),
+    );
+    expect(calculations).toHaveLength(1);
+    expect(calculations[0]).toMatchObject({
+      id: '018f190f-0dc8-7487-b35d-123456789abc',
+      score: 5,
+      band: 'moderate',
+      createdAt: '2026-05-03T10:00:00.000Z',
+    });
+  });
+});

--- a/apps/web/src/lib/api/heart-score.test.ts
+++ b/apps/web/src/lib/api/heart-score.test.ts
@@ -1,6 +1,61 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { createHeartScoreCalculation, listHeartScoreCalculations } from './heart-score';
+import {
+  calculateHeartScoreRemote,
+  createHeartScoreCalculation,
+  listHeartScoreCalculations,
+} from './heart-score';
+
+describe('calculateHeartScoreRemote', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts HEART Score inputs to the remote calculate endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        inputs: {
+          history: 2,
+          ecg: 1,
+          age: 1,
+          riskFactors: 1,
+          troponin: 0,
+        },
+        score: 5,
+        band: 'moderate',
+        interpretation: '12-16.6% 6-week MACE risk. Admit for observation / further workup.',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await calculateHeartScoreRemote({
+      history: 2,
+      ecg: 1,
+      age: 1,
+      riskFactors: 1,
+      troponin: 0,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:4000/api/v1/calculators/heart-score/calculate',
+      expect.objectContaining({
+        body: JSON.stringify({
+          history: 2,
+          ecg: 1,
+          age: 1,
+          riskFactors: 1,
+          troponin: 0,
+        }),
+        method: 'POST',
+      }),
+    );
+    expect(result).toMatchObject({
+      score: 5,
+      band: 'moderate',
+    });
+  });
+});
 
 describe('listHeartScoreCalculations', () => {
   afterEach(() => {

--- a/apps/web/src/lib/api/heart-score.test.ts
+++ b/apps/web/src/lib/api/heart-score.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { listHeartScoreCalculations } from './heart-score';
+import { createHeartScoreCalculation, listHeartScoreCalculations } from './heart-score';
 
 describe('listHeartScoreCalculations', () => {
   afterEach(() => {
@@ -43,6 +43,60 @@ describe('listHeartScoreCalculations', () => {
       score: 5,
       band: 'moderate',
       createdAt: '2026-05-03T10:00:00.000Z',
+    });
+  });
+});
+
+describe('createHeartScoreCalculation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts HEART Score inputs and returns the persisted calculation', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        id: '018f190f-0dc8-7487-b35d-123456789abc',
+        inputs: {
+          history: 2,
+          ecg: 1,
+          age: 1,
+          riskFactors: 1,
+          troponin: 0,
+        },
+        score: 5,
+        band: 'moderate',
+        interpretation: '12-16.6% 6-week MACE risk. Admit for observation / further workup.',
+        createdAt: '2026-05-03T10:00:00.000Z',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const calculation = await createHeartScoreCalculation({
+      history: 2,
+      ecg: 1,
+      age: 1,
+      riskFactors: 1,
+      troponin: 0,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:4000/api/v1/calculators/heart-score/calculations',
+      expect.objectContaining({
+        body: JSON.stringify({
+          history: 2,
+          ecg: 1,
+          age: 1,
+          riskFactors: 1,
+          troponin: 0,
+        }),
+        method: 'POST',
+      }),
+    );
+    expect(calculation).toMatchObject({
+      id: '018f190f-0dc8-7487-b35d-123456789abc',
+      score: 5,
+      band: 'moderate',
     });
   });
 });

--- a/apps/web/src/lib/api/heart-score.ts
+++ b/apps/web/src/lib/api/heart-score.ts
@@ -14,9 +14,12 @@ const BASE = '/api/v1/calculators/heart-score';
  * to the API for this feature.
  */
 export async function calculateHeartScoreRemote(
-  _input: HeartScoreInput,
+  input: HeartScoreInput,
 ): Promise<HeartScoreResult> {
-  throw new Error('not implemented');
+  return apiFetch<HeartScoreResult>(`${BASE}/calculate`, {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
 }
 
 export async function createHeartScoreCalculation(

--- a/apps/web/src/lib/api/heart-score.ts
+++ b/apps/web/src/lib/api/heart-score.ts
@@ -8,14 +8,7 @@ import { apiFetch } from './client';
 
 const BASE = '/api/v1/calculators/heart-score';
 
-/**
- * TODO(candidate): implement these three helpers against the endpoints you
- * build in the API. They are the only functions the UI should use to talk
- * to the API for this feature.
- */
-export async function calculateHeartScoreRemote(
-  input: HeartScoreInput,
-): Promise<HeartScoreResult> {
+export async function calculateHeartScoreRemote(input: HeartScoreInput): Promise<HeartScoreResult> {
   return apiFetch<HeartScoreResult>(`${BASE}/calculate`, {
     method: 'POST',
     body: JSON.stringify(input),

--- a/apps/web/src/lib/api/heart-score.ts
+++ b/apps/web/src/lib/api/heart-score.ts
@@ -20,9 +20,12 @@ export async function calculateHeartScoreRemote(
 }
 
 export async function createHeartScoreCalculation(
-  _input: HeartScoreInput,
+  input: HeartScoreInput,
 ): Promise<PersistedHeartScoreCalculation> {
-  throw new Error('not implemented');
+  return apiFetch<PersistedHeartScoreCalculation>(`${BASE}/calculations`, {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
 }
 
 export async function listHeartScoreCalculations(

--- a/apps/web/src/lib/api/heart-score.ts
+++ b/apps/web/src/lib/api/heart-score.ts
@@ -13,7 +13,9 @@ const BASE = '/api/v1/calculators/heart-score';
  * build in the API. They are the only functions the UI should use to talk
  * to the API for this feature.
  */
-export async function calculateHeartScoreRemote(_input: HeartScoreInput): Promise<HeartScoreResult> {
+export async function calculateHeartScoreRemote(
+  _input: HeartScoreInput,
+): Promise<HeartScoreResult> {
   throw new Error('not implemented');
 }
 
@@ -24,11 +26,7 @@ export async function createHeartScoreCalculation(
 }
 
 export async function listHeartScoreCalculations(
-  _limit = 20,
+  limit = 20,
 ): Promise<PersistedHeartScoreCalculation[]> {
-  throw new Error('not implemented');
+  return apiFetch<PersistedHeartScoreCalculation[]>(`${BASE}/calculations?limit=${limit}`);
 }
-
-// Keep the import referenced until the candidate wires it up.
-void BASE;
-void apiFetch;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "baseUrl": ".",
     "jsx": "preserve",
     "incremental": true,
     "noEmit": true,
@@ -10,31 +11,14 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./src/*"
-      ],
-      "@mdcalc/shared": [
-        "../../packages/shared/src/index.ts"
-      ],
-      "@mdcalc/shared/*": [
-        "../../packages/shared/src/*"
-      ],
-      "@mdcalc/ui": [
-        "../../packages/ui/src/index.ts"
-      ],
-      "@mdcalc/ui/*": [
-        "../../packages/ui/src/*"
-      ]
+      "@/*": ["./src/*"],
+      "@mdcalc/shared": ["../../packages/shared/src/index.ts"],
+      "@mdcalc/shared/*": ["../../packages/shared/src/*"],
+      "@mdcalc/ui": ["../../packages/ui/src/index.ts"],
+      "@mdcalc/ui/*": ["../../packages/ui/src/*"]
     },
     "allowJs": true
   },
-  "include": [
-    "next-env.d.ts",
-    "src/**/*.ts",
-    "src/**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,6 +32,46 @@
   validation before submit.
 - Errors leave the API in the shape `{ error: { code, message, details? } }`.
 
-## Candidate: add your feature notes here
+## HEART Score Data Flow
 
-<!-- TODO(candidate): describe how your HEART Score feature is wired. -->
+The HEART Score implementation is centered on `@mdcalc/shared`. That package
+defines the five scored inputs with zod, exports the shared TypeScript types,
+and owns the pure `calculateHeartScore` function that maps validated inputs to
+score, risk band, interpretation, and echoed inputs. The web app imports that
+same calculator for the live preview, while the API imports the same schema and
+calculator so browser-provided results are never trusted.
+
+```
+[ HeartScoreCalculator client component ]
+       |
+       |-- live preview via @mdcalc/shared/calculateHeartScore
+       |
+       `-- POST/GET through apps/web/src/lib/api/heart-score.ts
+                         |
+                         v
+[ Express router ] --validateBody(heartScoreInputSchema)--> [ controller ]
+                         |                                      |
+                         v                                      v
+                [ heart-score.service ] -------------> calculateHeartScore
+                         |
+                         v
+              [ heart-score.repository ]
+                         |
+                         v
+        [ heart_score_calculations Postgres table ]
+```
+
+`POST /api/v1/calculators/heart-score/calculate` validates the request body at
+the router boundary and returns the shared calculation result without touching
+the database. `POST /api/v1/calculators/heart-score/calculations` follows the
+same validation path, then the service recomputes score, band, and
+interpretation before persistence. The repository inserts only server-computed
+results and maps database `created_at` rows back to the camelCase DTO used by
+the web app.
+
+Recent calculations are intentionally bounded at the HTTP layer:
+`GET /api/v1/calculators/heart-score/calculations` defaults to 20 rows and
+rejects non-integer, less-than-one, or greater-than-100 limits before repository
+access. The Next.js route keeps page metadata server-rendered, and the
+interactive form, save state, and recent-list refresh token live in the client
+HEART Score component.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-```
+```text
 [ Browser ]
      │
      ▼
@@ -41,7 +41,7 @@ score, risk band, interpretation, and echoed inputs. The web app imports that
 same calculator for the live preview, while the API imports the same schema and
 calculator so browser-provided results are never trusted.
 
-```
+```text
 [ HeartScoreCalculator client component ]
        |
        |-- live preview via @mdcalc/shared/calculateHeartScore

--- a/packages/shared/src/calculators/heart-score/calculate.test.ts
+++ b/packages/shared/src/calculators/heart-score/calculate.test.ts
@@ -4,6 +4,17 @@ import { calculateHeartScore } from './calculate';
 import { heartScoreInputSchema, type HeartScoreInput } from '../../schemas/heart-score';
 
 describe('calculateHeartScore', () => {
+  it('returns the low-risk band for the minimum score', () => {
+    const inputs: HeartScoreInput = { history: 0, ecg: 0, age: 0, riskFactors: 0, troponin: 0 };
+
+    expect(calculateHeartScore(inputs)).toEqual({
+      score: 0,
+      band: 'low',
+      interpretation: '0.9-1.7% 6-week MACE risk. Consider discharge.',
+      inputs,
+    });
+  });
+
   it('returns the low-risk band through score 3', () => {
     const inputs: HeartScoreInput = { history: 1, ecg: 0, age: 1, riskFactors: 1, troponin: 0 };
 
@@ -39,6 +50,17 @@ describe('calculateHeartScore', () => {
       score: 7,
       band: 'high',
       interpretation: '50-65% 6-week MACE risk. Early invasive strategy.',
+    });
+  });
+
+  it('returns the high-risk band for the maximum score', () => {
+    const inputs: HeartScoreInput = { history: 2, ecg: 2, age: 2, riskFactors: 2, troponin: 2 };
+
+    expect(calculateHeartScore(inputs)).toEqual({
+      score: 10,
+      band: 'high',
+      interpretation: '50-65% 6-week MACE risk. Early invasive strategy.',
+      inputs,
     });
   });
 });

--- a/packages/shared/src/calculators/heart-score/calculate.test.ts
+++ b/packages/shared/src/calculators/heart-score/calculate.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { calculateHeartScore } from './calculate';
+import { heartScoreInputSchema, type HeartScoreInput } from '../../schemas/heart-score';
+
+describe('calculateHeartScore', () => {
+  it('returns the low-risk band through score 3', () => {
+    const inputs: HeartScoreInput = { history: 1, ecg: 0, age: 1, riskFactors: 1, troponin: 0 };
+
+    expect(calculateHeartScore(inputs)).toEqual({
+      score: 3,
+      band: 'low',
+      interpretation: '0.9-1.7% 6-week MACE risk. Consider discharge.',
+      inputs,
+    });
+  });
+
+  it('returns the moderate-risk band for scores 4 through 6', () => {
+    expect(
+      calculateHeartScore({ history: 2, ecg: 0, age: 1, riskFactors: 1, troponin: 0 }),
+    ).toMatchObject({
+      score: 4,
+      band: 'moderate',
+      interpretation: '12-16.6% 6-week MACE risk. Admit for observation / further workup.',
+    });
+
+    expect(
+      calculateHeartScore({ history: 2, ecg: 1, age: 1, riskFactors: 1, troponin: 1 }),
+    ).toMatchObject({
+      score: 6,
+      band: 'moderate',
+    });
+  });
+
+  it('returns the high-risk band from score 7', () => {
+    expect(
+      calculateHeartScore({ history: 2, ecg: 2, age: 1, riskFactors: 1, troponin: 1 }),
+    ).toMatchObject({
+      score: 7,
+      band: 'high',
+      interpretation: '50-65% 6-week MACE risk. Early invasive strategy.',
+    });
+  });
+});
+
+describe('heartScoreInputSchema', () => {
+  it('rejects scored inputs outside the HEART range', () => {
+    const result = heartScoreInputSchema.safeParse({
+      history: 3,
+      ecg: 0,
+      age: 1,
+      riskFactors: 1,
+      troponin: 0,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/src/calculators/heart-score/calculate.ts
+++ b/packages/shared/src/calculators/heart-score/calculate.ts
@@ -1,21 +1,33 @@
+import type { RiskBand } from '../../types/calculators';
 import type { HeartScoreInput } from '../../schemas/heart-score';
 import type { HeartScoreResult } from './types';
 
-/**
- * Pure calculation for the HEART Score. Lives in the shared package so the
- * API and the web client can render the same live preview.
- *
- * TODO(candidate):
- *   1. Sum the five numeric inputs into `score`.
- *   2. Map the total to a `band` using the ranges in
- *      `docs/heart-score-reference.md`.
- *   3. Return a human-readable `interpretation` that mentions the 6-week
- *      MACE risk for that band.
- *
- * This function MUST NOT throw — it assumes its input has already been
- * validated against `heartScoreInputSchema`. Callers that accept untrusted
- * input should parse with the schema first.
- */
-export function calculateHeartScore(_input: HeartScoreInput): HeartScoreResult {
-  throw new Error('calculateHeartScore is not implemented yet');
+const bandInterpretations: Record<RiskBand, string> = {
+  low: '0.9-1.7% 6-week MACE risk. Consider discharge.',
+  moderate: '12-16.6% 6-week MACE risk. Admit for observation / further workup.',
+  high: '50-65% 6-week MACE risk. Early invasive strategy.',
+};
+
+function getBand(score: number): RiskBand {
+  if (score <= 3) {
+    return 'low';
+  }
+
+  if (score <= 6) {
+    return 'moderate';
+  }
+
+  return 'high';
+}
+
+export function calculateHeartScore(input: HeartScoreInput): HeartScoreResult {
+  const score = input.history + input.ecg + input.age + input.riskFactors + input.troponin;
+  const band = getBand(score);
+
+  return {
+    score,
+    band,
+    interpretation: bandInterpretations[band],
+    inputs: input,
+  };
 }

--- a/packages/shared/src/schemas/heart-score.ts
+++ b/packages/shared/src/schemas/heart-score.ts
@@ -1,17 +1,13 @@
 import { z } from 'zod';
 
-/**
- * TODO(candidate): Define a zod schema that validates a HEART Score payload.
- *
- * Each of the five inputs (history, ecg, age, riskFactors, troponin) must be
- * constrained to the integer values 0, 1, or 2. See
- * `docs/heart-score-reference.md` for the allowed values per input.
- *
- * Export both the schema and its inferred type so the API and web layers
- * can share a single contract.
- */
+const scoredHeartInput = z.union([z.literal(0), z.literal(1), z.literal(2)]);
+
 export const heartScoreInputSchema = z.object({
-  // TODO(candidate): replace with real fields
+  history: scoredHeartInput,
+  ecg: scoredHeartInput,
+  age: scoredHeartInput,
+  riskFactors: scoredHeartInput,
+  troponin: scoredHeartInput,
 });
 
 export type HeartScoreInput = z.infer<typeof heartScoreInputSchema>;

--- a/packages/ui/src/components/Card.tsx
+++ b/packages/ui/src/components/Card.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes, ReactNode } from 'react';
 
-export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+export interface CardProps extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
   title?: ReactNode;
   footer?: ReactNode;
 }


### PR DESCRIPTION
## Summary

Implements the HEART Score for Major Cardiac Events across the shared package, API, database, web UI, and submission docs.

PRD: #1

## Key Decisions

- Centralized HEART Score input validation, TypeScript types, and scoring logic in `@mdcalc/shared` to avoid contract drift between web and API.
- Kept persistence server-authoritative: clients submit only the five scored inputs, and the API recomputes score, band, and interpretation before insert.
- Followed the existing API layering with router validation, thin controllers, service orchestration, repository-owned SQL, and camelCase DTO mapping.
- Added bounded recent-calculations listing with default limit `20`, max `100`, and early rejection of invalid limits.
- Kept the Next.js route metadata server-rendered while moving calculator form state, save state, and recent-list refresh coordination into the client component.
- Avoided adding a data-fetching dependency; a local refresh token is sufficient for this page's save-and-refresh workflow.

## Files Changed

- Shared HEART Score contract and calculator: `packages/shared/src/schemas/heart-score.ts`, `packages/shared/src/calculators/heart-score/*`
- API endpoints, service, repository, migration, and integration tests: `apps/api/src/modules/calculators/heart-score/*`, `apps/api/src/db/migrations/002_heart_score_calculations.sql`, `apps/api/tests/calculators/heart-score.test.ts`
- Web calculator UI, recent calculations, API helper, and tests: `apps/web/src/app/calculators/heart-score/page.tsx`, `apps/web/src/components/calculators/heart-score/*`, `apps/web/src/lib/api/heart-score*`
- Supporting type fixes: `apps/web/tsconfig.json`, `packages/ui/src/components/Card.tsx`
- Submission docs: `docs/architecture.md`, `NOTES.md`

## Verification

- `npm run test`
- `npm run test --workspace @mdcalc/api`
- `npm run test --workspace @mdcalc/shared`
- `npm run test --workspace @mdcalc/web`
- `npm run typecheck --workspace @mdcalc/shared`
- `npm run typecheck --workspace @mdcalc/web`
- `npm run typecheck --workspace @mdcalc/ui`
- `git diff --check`

## Known Limits / Next Iteration

- Root `npm run typecheck` is still blocked by pre-existing API workspace `rootDir` and `pino-http` type issues.
- Root `npm run lint` is not currently a final gate because the repo does not include an ESLint config.
- Browser E2E and live Postgres manual verification were not added in this pass.
- Production concerns such as auth, clinician identity, audit logging, rate limiting, and patient-level clinical context are intentionally out of scope for the assignment slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HEART Score calculator with real-time result computation and save functionality
  * Browse recent calculations with configurable pagination
  * API endpoints for calculation persistence and retrieval

* **Documentation**
  * Added project setup guide and data flow architecture documentation

* **Tests**
  * Full test coverage for calculator functionality, API endpoints, and input validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->